### PR TITLE
fix: Promise .then() must ignore non-function handlers per Promises/A+ 2.2.1

### DIFF
--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -1427,9 +1427,9 @@
       "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q=="
     },
     "node_modules/@types/node": {
-      "version": "25.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
-      "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }

--- a/lib/src/promise/base.ts
+++ b/lib/src/promise/base.ts
@@ -145,7 +145,8 @@ export function _createPromise<T>(newPromise: PromiseCreatorFn, processor: Promi
                         _debugLog(_toString(), "Handling settled value " + dumpFnObj(_settledValue));
                         //#endif
                         let handler = _state === ePromiseState.Resolved ? onResolved : onRejected;
-                        let value = isUndefined(handler) ? _settledValue : (isFunction(handler) ? handler(_settledValue) : handler);
+                        // Promises/A+ 2.2.1: If onFulfilled/onRejected is not a function, it must be ignored
+                        let value = isFunction(handler) ? handler(_settledValue) : _settledValue;
                         //#ifdef DEBUG
                         _debugLog(_toString(), "Handling Result " + dumpFnObj(value));
                         //#endif
@@ -154,7 +155,7 @@ export function _createPromise<T>(newPromise: PromiseCreatorFn, processor: Promi
                             // The called handlers returned a new promise, so the chained promise
                             // will follow the state of this promise.
                             value.then(resolve as any, reject);
-                        } else if (handler) {
+                        } else if (isFunction(handler)) {
                             // If we have a handler then chained promises are always "resolved" with the result returned
                             resolve(value as any);
                         } else if (_state === ePromiseState.Rejected) {

--- a/lib/test/src/promise/use.await.test.ts
+++ b/lib/test/src/promise/use.await.test.ts
@@ -200,8 +200,9 @@ describe("Validate Promise Await Usage tests", async () => {
     objForEachKey(testImplementations, (testKey, definition) => {
         describe(`Testing [${testKey}] promise implementation`, function () {
             if (testKey === "idle") {
-                // Extend the default timeout for idle tests
-                this.timeout(10000);
+                // Extend the default timeout for idle tests as requestIdleCallback
+                // without a deadline can be deferred in headless browsers
+                this.timeout(30000);
             }
     
             batchTests(testKey, definition);


### PR DESCRIPTION
When .then() receives a non-function, non-undefined handler, it incorrectly uses the handler value as the resolved value instead of passing through the settled value. This violates Promises/A+ spec section 2.2.1 which states that non-function handlers must be ignored.

Changes:
- Use isFunction(handler) check instead of isUndefined(handler) to determine whether to invoke the handler or pass through the settled value
- Use isFunction(handler) instead of truthy check to determine the resolve/ reject path for the chained promise
- Increase idle promise test timeout from 10s to 30s to account for requestIdleCallback deferral in headless browsers