### PR TITLE
chore: Address issues with /*#__PURE__*/ annotations placed inside parens cause Rolldown/Vite 8

### DIFF
--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -535,11 +535,21 @@
       }
     },
     "node_modules/@nevware21/ts-async": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.5.tgz",
-      "integrity": "sha512-vwqaL05iJPjLeh5igPi8MeeAu10i+Aq7xko1fbo9F5Si6MnVN5505qaV7AhSdk5MCBJVT/UYMk3kgInNjDb4Ig==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.6.0.tgz",
+      "integrity": "sha512-pSc2Ynrz66bMDqs8Sw5qQOU4oeOLzFCeheAHJ6HZWpVz8yPGlZV4Ur03PiWli6qlFGR3Xls9Aov2TZRVb+izUA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nevware21"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/nevware21"
+        }
+      ],
       "dependencies": {
-        "@nevware21/ts-utils": ">= 0.12.2 < 2.x"
+        "@nevware21/ts-utils": ">= 0.15.0 < 2.x"
       }
     },
     "node_modules/@nevware21/ts-preproc": {
@@ -5474,9 +5484,19 @@
       }
     },
     "node_modules/mocha/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/lib/rollup.config.js
+++ b/lib/rollup.config.js
@@ -3,6 +3,7 @@ import commonjs from "@rollup/plugin-commonjs";
 import cleanup from 'rollup-plugin-cleanup';
 import minify from "rollup-plugin-minify-es";
 import sourcemaps from 'rollup-plugin-sourcemaps';
+import MagicString from 'magic-string';
 
 const UglifyJs = require('uglify-js');
 
@@ -78,6 +79,45 @@ export function uglify3(options = {}) {
             return _doMinify(code, chunk.filename, options, chkOpt);
         }
     }
+}
+
+// Normalize the emitted spacing of PURE annotations that sit inside parentheses.
+// (Token sequences are described in prose below rather than written literally so
+// Rollup's own annotation scanner does not flag this comment while loading the
+// config.) The wrapping parens are kept deliberately - they preserve tree-shaking
+// on older Rollup/Webpack/Terser toolchains that only honor the annotation when it
+// hugs the call. However TypeScript (and some source sites) emit the annotation
+// with whitespace after the open paren - an open paren, a space, then the comment -
+// which Rolldown (Vite 8) treats as an invalid annotation location and ignores,
+// emitting [INVALID_ANNOTATION] and losing DCE. This rewrites those spaced forms
+// (including the inner-space variant and the at-sign spelling) back to the
+// canonical form with the comment flush against the open paren, which every
+// bundler accepts. Uses magic-string so the generated sourcemap stays valid.
+export function fixPureAnnotations() {
+    const pureRe = /\(\s{0,5}\/\*\s{0,5}([#@])__PURE__\s{0,5}\*\//g;
+
+    return {
+        name: "fix-pure-annotations",
+        renderChunk(code) {
+            const magic = new MagicString(code);
+
+            for (const match of code.matchAll(pureRe)) {
+                const canonical = "(/*" + match[1] + "__PURE__*/";
+                if (match[0] !== canonical) {
+                    magic.overwrite(match.index, match.index + match[0].length, canonical);
+                }
+            }
+
+            if (!magic.hasChanged()) {
+                return null;
+            }
+
+            return {
+                code: magic.toString(),
+                map: magic.generateMap({ hires: true })
+            };
+        }
+    };
 }
 
 function sourcemapTransformer(options) {
@@ -177,6 +217,9 @@ const rollupConfigFactory = (srcPath, destPath, isMinified, path, format = "iife
         }
     }
 
+    // Run last so it normalizes the final emitted chunk (after uglify on minified targets)
+    taskRollupConfig.plugins.push(fixPureAnnotations());
+
     return taskRollupConfig;
 };
 
@@ -211,7 +254,8 @@ const rollupConfigMainEntry = (srcPath, destPath, path, format = "umd") => {
                     "some",
                     "ts"
                 ]
-            })
+            }),
+            fixPureAnnotations()
         ]
     };
 
@@ -266,6 +310,9 @@ const polyfillRollupConfigFactory = (srcPath, destPath, isMinified, format = "ii
             })
         );
     }
+
+    // Run last so it normalizes the final emitted chunk (after uglify on minified targets)
+    taskRollupConfig.plugins.push(fixPureAnnotations());
 
     return taskRollupConfig;
 };

--- a/lib/test/bundle-pure-annotations-check.js
+++ b/lib/test/bundle-pure-annotations-check.js
@@ -1,0 +1,79 @@
+const fs = require("fs");
+const path = require("path");
+
+const outputRoots = [
+    path.join(__dirname, "../bundle"),
+    path.join(__dirname, "../dist")
+];
+
+const invalidPureAnnotationRe = /\(\s+\/\*\s*([#@])__PURE__\s*\*\//g;
+
+function collectJsFiles(rootPath, output) {
+    if (!fs.existsSync(rootPath)) {
+        return;
+    }
+
+    fs.readdirSync(rootPath).forEach((name) => {
+        const fullPath = path.join(rootPath, name);
+        const stat = fs.statSync(fullPath);
+
+        if (stat.isDirectory()) {
+            collectJsFiles(fullPath, output);
+            return;
+        }
+
+        if (stat.isFile() && path.extname(name) === ".js") {
+            output.push(fullPath);
+        }
+    });
+}
+
+function getLineNumber(content, index) {
+    let line = 1;
+    for (let lp = 0; lp < index; lp++) {
+        if (content.charCodeAt(lp) === 10) {
+            line++;
+        }
+    }
+
+    return line;
+}
+
+const jsFiles = [];
+outputRoots.forEach((rootPath) => collectJsFiles(rootPath, jsFiles));
+
+if (jsFiles.length === 0) {
+    console.error("No generated JavaScript files were found under lib/bundle or lib/dist");
+    process.exit(1);
+}
+
+const failures = [];
+
+console.log("Scanning generated JavaScript files for PURE annotation spacing...");
+console.log("Files discovered: " + jsFiles.length);
+
+jsFiles.forEach((filePath) => {
+    const relativeFilePath = path.relative(process.cwd(), filePath).replace(/\\/g, "/");
+    console.log(" - Processing " + relativeFilePath);
+    const content = fs.readFileSync(filePath, "utf8");
+    let match;
+
+    invalidPureAnnotationRe.lastIndex = 0;
+    while ((match = invalidPureAnnotationRe.exec(content))) {
+        failures.push({
+            filePath: relativeFilePath,
+            line: getLineNumber(content, match.index),
+            sample: match[0]
+        });
+    }
+});
+
+if (failures.length > 0) {
+    console.error("Found invalid PURE annotations with leading whitespace after '(':");
+    failures.forEach((failure) => {
+        console.error(" - " + failure.filePath + ":" + failure.line + " -> " + failure.sample);
+    });
+    process.exit(1);
+}
+
+console.log("PURE annotation spacing check passed for generated bundle/dist JavaScript files.");

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "npm-publish": "publish-npm -c ./publish-groups.json",
         "preproc-restore": "ts-preproc-restore -c ./preproc.json",
         "size": "size-limit",
-        "size-check": "node lib/test/bundle-size-check.js",
+        "size-check": "node lib/test/bundle-size-check.js && node lib/test/bundle-pure-annotations-check.js",
         "link-check": "node lib/test/readme-links-check.mjs",
         "readme-link-check": "npm run docs && npm run link-check"
     },
@@ -118,6 +118,7 @@
         "eslint-plugin-security": "^1.7.1",
         "grunt": "^1.6.2",
         "grunt-cli": "^1.4.3",
+        "magic-string": "^0.30.21",
         "nyc": "^18.0.0",
         "size-limit": "^12.0.0",
         "typedoc": "^0.28.2",


### PR DESCRIPTION
- address issues with /*#__PURE__*/ annotations placed inside parens cause Rolldown/Vite 8 [INVALID_ANNOTATION] warnings and disable tree-shaking
- add a generated-artifact validation script at bundle-pure-annotations-check.js to scan packaged JavaScript under bundle and dist outputs
- fail when PURE annotations have whitespace after opening parenthesis, and report file plus line for quick diagnosis
- add progress logging to show discovered files and each file being processed
- run the new validation as part of size-check in package.json
- widen the PURE annotation normalization spacing matcher in rollup.config.js to tolerate larger whitespace ranges before rewriting to canonical form