### PR TITLE
feat: Guard against unbounded synchronous promise chain recursion

### DIFF
--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -2,6 +2,10 @@
 
 ## Changelog
 
+- [#527](https://github.com/nevware21/ts-async/pull/527) [Feature] Add `setMaxSyncPromiseChainDepth` to cap synchronous promise chain depth
+  - New exported function `setMaxSyncPromiseChainDepth(maxDepth?: number)` allows configuring the maximum number of synchronous `.then()` continuations that may execute in a single turn before the chain is deferred via a microtask hop. Defaults to 200.
+  - **Behavior change**: deep synchronous promise chains (longer than the configured max depth) will yield asynchronously once the limit is exceeded, meaning a `createSyncPromise`/`createSyncResolvedPromise` chain may remain pending temporarily for very deep/recursive chains.
+  - Pass no argument (or `undefined`) to reset back to the default depth.
 
 # v0.6.1 May 31st, 2026
 

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -18,6 +18,7 @@ export {
 } from "./interfaces/types"
 export { doAwaitResponse, doAwait, doFinally } from "./promise/await";
 export { setPromiseDebugState } from "./promise/debug";
+export { setMaxSyncPromiseChainDepth } from "./promise/itemProcessor";
 export {
     createNativePromise, createNativeAllPromise, createNativeResolvedPromise, createNativeRejectedPromise,
     createNativeAnyPromise, createNativeRacePromise,

--- a/lib/src/promise/itemProcessor.ts
+++ b/lib/src/promise/itemProcessor.ts
@@ -15,6 +15,70 @@ export type PromisePendingProcessor = (pending: PromisePendingFn[]) => void;
 export type PromisePendingFn = () => void;
 export type PromiseCreatorFn = <T, TResult2 = never>(newExecutor: PromiseExecutor<T>, ...extraArgs: any) => IPromise<T | TResult2>;
 
+/**
+ * @internal
+ * @ignore
+ * The default value used by {@link setMaxSyncPromiseChainDepth}, see {@link _maxSyncChainDepth}
+ */
+const DEFAULT_MAX_SYNC_CHAIN_DEPTH = 200;
+
+/**
+ * @internal
+ * @ignore
+ * The currently configured maximum number of consecutive promise reaction continuations that will be
+ * executed synchronously (in the same call stack) before a microtask "hop" is forced, see
+ * {@link setMaxSyncPromiseChainDepth}.
+ */
+let _maxSyncChainDepth = DEFAULT_MAX_SYNC_CHAIN_DEPTH;
+
+/**
+ * @internal
+ * @ignore
+ * Tracks how many promise reaction continuations have been executed consecutively within the current
+ * synchronous call stack. This is incremented immediately before, and decremented immediately after,
+ * invoking a pending continuation, so it behaves as a simple call-stack depth counter -- it is restored
+ * back to its previous value once any nested (recursively chained) continuations have unwound, and it
+ * is always back at zero by the time any genuine asynchronous callback (a timer, microtask or idle
+ * callback) is invoked, as the JS call stack is guaranteed to be empty at that point.
+ */
+let _syncChainDepth = 0;
+
+/**
+ * Sets the maximum number of consecutive promise reaction continuations (chained `then`/`catch`/`finally`
+ * handlers becoming ready to run) that will be executed synchronously, within the same JavaScript call
+ * stack, before this library forces an async "hop" (microtask; or a 0ms timeout when Sinon fake timers
+ * are enabled) to unwind the stack before continuing. This is a safety-net against unbounded call-stack
+ * growth (and eventual `RangeError: Maximum call stack size exceeded`) which could otherwise occur when
+ * synchronously resolving very deep or recursively chained promises, or a "hostile" thenable whose
+ * `then()` implementation resolves itself recursively and synchronously.
+ * The depth is only ever consumed while continuations are being run synchronously (eg. via
+ * {@link createSyncPromise}, or once an asynchronous processor's own timer / microtask / idle callback
+ * has already fired). When the limit is exceeded, the current continuation is deferred so the stack can
+ * unwind; this means very deep / recursive "sync" chains may yield asynchronously. The depth is
+ * automatically restored (effectively "reset") once execution returns to, or is resumed from, a genuine
+ * asynchronous boundary.
+ * @since 0.7.0
+ * @group Promise
+ * @param maxDepth - The maximum number of consecutive synchronous continuations to allow before forcing
+ * an asynchronous (microtask) hop. Defaults to 200 when omitted / non-numeric. Passing zero or a negative
+ * value disables the guard so that continuations are always executed synchronously (the previous,
+ * unbounded, behavior) -- this is not recommended other than for compatibility purposes.
+ * @example
+ * ```ts
+ * // Reduce the depth for more constrained environments
+ * setMaxSyncPromiseChainDepth(50);
+ *
+ * // Disable the guard (not recommended)
+ * setMaxSyncPromiseChainDepth(0);
+ *
+ * // Restore the default
+ * setMaxSyncPromiseChainDepth(200);
+ * ```
+ */
+export function setMaxSyncPromiseChainDepth(maxDepth?: number): void {
+    _maxSyncChainDepth = isNumber(maxDepth) ? maxDepth : DEFAULT_MAX_SYNC_CHAIN_DEPTH;
+}
+
 function _isFakeTimersEnabled(): boolean {
     // Sinon fake timers patch setTimeout and expose the active clock instance as `setTimeout.clock`.
     // This check intentionally targets that behavior so async promise callbacks remain testable with fake clocks.
@@ -25,18 +89,49 @@ function _isFakeTimersEnabled(): boolean {
 /**
  * @internal
  * @ignore
+ * Executes the given pending continuation, tracking (and bounding) how many consecutive synchronous
+ * continuations have been executed. Once the configured maximum ({@link setMaxSyncPromiseChainDepth})
+ * has been reached, the continuation is instead deferred via a microtask (or a 0ms timeout when Sinon
+ * fake timers are enabled) so the call stack can unwind; the depth is naturally back at zero by the
+ * time that deferred continuation actually runs.
+ * @param fn - The pending continuation to execute
+ */
+function _runPendingItem(fn: PromisePendingFn): void {
+    if (_maxSyncChainDepth > 0 && _syncChainDepth >= _maxSyncChainDepth) {
+        let pendingFn = function () {
+            _runPendingItem(fn);
+        };
+
+        if (_isFakeTimersEnabled()) {
+            // Under Sinon fake timers, queued microtasks are not advanced by clock ticks in this test suite,
+            // so use setTimeout(0) to keep callback progression deterministic while fake timers are active.
+            scheduleTimeout(pendingFn, 0);
+        } else {
+            scheduleMicrotask(pendingFn);
+        }
+
+        return;
+    }
+
+    _syncChainDepth++;
+    try {
+        fn();
+    } catch (e) {
+        // Don't let 1 failing handler break all others
+        // TODO: Add some form of error reporting (i.e. Call any registered JS error handler so the error is reported)
+    } finally {
+        _syncChainDepth--;
+    }
+}
+
+/**
+ * @internal
+ * @ignore
  * Return an item processor that processes all of the pending items synchronously
  * @return An item processor
  */
 export function syncItemProcessor(pending: PromisePendingFn[]): void {
-    arrForEach(pending, (fn: PromisePendingFn) => {
-        try {
-            fn();
-        } catch (e) {
-            // Don't let 1 failing handler break all others
-            // TODO: Add some form of error reporting (i.e. Call any registered JS error handler so the error is reported)
-        }
-    });
+    arrForEach(pending, _runPendingItem);
 }
 
 /**

--- a/lib/test/bundle-size-check.js
+++ b/lib/test/bundle-size-check.js
@@ -7,7 +7,7 @@ const configs = [
   {
     name: "es5-min-full",
     path: "../bundle/es5/umd/ts-async.min.js",
-    limit: 18.75 * 1024, // 18.75 kb in bytes
+    limit: 19 * 1024, // 19 kb in bytes
     compress: false
   },
   {

--- a/lib/test/src/promise/syncChainDepth.test.ts
+++ b/lib/test/src/promise/syncChainDepth.test.ts
@@ -1,0 +1,94 @@
+/*
+ * @nevware21/ts-async
+ * https://github.com/nevware21/ts-async
+ *
+ * Copyright (c) 2026 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { assert } from "@nevware21/tripwire";
+import { IPromise } from "../../../src/interfaces/IPromise";
+import { createSyncResolvedPromise } from "../../../src/promise/syncPromise";
+import { setMaxSyncPromiseChainDepth } from "../../../src/promise/itemProcessor";
+
+describe("Validate synchronous promise chain depth guard", () => {
+
+    afterEach(() => {
+        // Restore the default guard depth after each test so it doesn't leak into other test files
+        setMaxSyncPromiseChainDepth();
+    });
+
+    // Builds a promise chain that recursively resolves itself by returning a new (already
+    // resolved) chained promise from within the previous link's `then()` handler -- this is
+    // the "recursive thenable" pattern that can grow the JS call stack by one or more frames
+    // for every link when processed entirely synchronously.
+    function _recursiveChain(value: number, remaining: number, log: number[]): IPromise<number> {
+        return createSyncResolvedPromise(value).then((v) => {
+            log.push(v);
+            if (remaining <= 0) {
+                return v;
+            }
+
+            return _recursiveChain(v + 1, remaining - 1, log);
+        });
+    }
+
+    it("resolves a shallow recursively-chained promise entirely synchronously", () => {
+        let log: number[] = [];
+        let promise = _recursiveChain(0, 10, log) as IPromise<number>;
+
+        assert.equal(promise.state, "resolved", "A shallow chain should complete synchronously (under the default guard depth)");
+        assert.equal(log.length, 11, "Expecting all 11 links to have run");
+    });
+
+    it("does not overflow the call stack for a very deep recursively-chained promise", async function () {
+        // Well beyond the default guard depth (200) -- generous timeout as this needs several
+        // microtask hops to fully unwind, which can be slower on a heavily loaded machine/CI runner.
+        this.timeout(30000);
+
+        let log: number[] = [];
+        let depth = 1500;
+        let promise = _recursiveChain(0, depth, log) as IPromise<number>;
+
+        let result = await promise;
+        assert.equal(result, depth, "Expecting the final value to be the last resolved value");
+        assert.equal(log.length, depth + 1, "Expecting every link in the chain to have run");
+    });
+
+    it("defers via a microtask once the configured maximum synchronous chain depth is exceeded", async () => {
+        setMaxSyncPromiseChainDepth(3);
+
+        let log: number[] = [];
+        let promise = _recursiveChain(0, 20, log) as IPromise<number>;
+
+        // With such a small configured depth the guard should have forced at least one
+        // microtask hop before the whole chain could complete synchronously.
+        assert.equal(promise.state, "pending", "Expecting the chain to not have completed synchronously");
+
+        let result = await promise;
+        assert.equal(result, 20, "Expecting the final value to be the last resolved value");
+        assert.equal(log.length, 21, "Expecting every link in the chain to have run");
+    });
+
+    it("can disable the guard by passing zero (or a negative) maxDepth", () => {
+        setMaxSyncPromiseChainDepth(0);
+
+        let log: number[] = [];
+        let promise = _recursiveChain(0, 300, log) as IPromise<number>;
+
+        assert.equal(promise.state, "resolved", "Expecting the chain to complete synchronously when the guard is disabled");
+        assert.equal(log.length, 301, "Expecting every link in the chain to have run");
+    });
+
+    it("resets back to the default depth when called without a value", () => {
+        setMaxSyncPromiseChainDepth(2);
+        setMaxSyncPromiseChainDepth();
+
+        // The default (200) should comfortably allow a moderate chain to complete synchronously
+        let log: number[] = [];
+        let promise = _recursiveChain(0, 50, log) as IPromise<number>;
+
+        assert.equal(promise.state, "resolved", "Expecting the default depth to be restored");
+        assert.equal(log.length, 51, "Expecting every link in the chain to have run");
+    });
+});


### PR DESCRIPTION
Resolving a very deep or "hostile" self-resolving thenable through createSyncPromise could grow the call stack without bound and overflow it. syncItemProcessor now tracks consecutive synchronous continuations and forces a microtask hop once a configurable depth  setMaxSyncPromiseChainDepth, default 200) is exceeded, letting the stack unwind before continuing.